### PR TITLE
Adding double quotes around the NugetExe and $WorkingFolder variables

### DIFF
--- a/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
+++ b/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
@@ -24,7 +24,8 @@ function Install-MicrosoftDataToolsMSBuild {
     if ($TestDotNetVersion.DWORD -le 394254) {
         Throw "Need to install .NET 4.6.1 at least!"
     }
-    $nugetInstallMsbuild = "&$NugetExe install Microsoft.Data.Tools.Msbuild -ExcludeVersion -OutputDirectory $WorkingFolder"
+    #putting the $NugetExe and $WorkingFolder in double-quotes in case there are spaces in the paths.
+    $nugetInstallMsbuild = "&`"$NugetExe`" install Microsoft.Data.Tools.Msbuild -ExcludeVersion -OutputDirectory `"$WorkingFolder`""
     if ($DataToolsMsBuildPackageVersion) {
         if ($DataToolsMsBuildPackageVersion -lt "10.0.61026") {
             Throw "Lower versions than 10.0.61026 will NOT work with Publish-DatabaseDeployment. For more information, read the post https://blogs.msdn.microsoft.com/ssdt/2016/10/20/sql-server-data-tools-16-5-release/"            

--- a/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
+++ b/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
@@ -39,7 +39,7 @@ function Install-MicrosoftDataToolsMSBuild {
     if (-not (Test-Path $SSDTMSbuildFolderNet46)) {
         $SSDTMSbuildFolderNet40 = "$WorkingFolder\Microsoft.Data.Tools.Msbuild\lib\net40"
         if (-not (Test-Path $SSDTMSbuildFolderNet40)) {
-            Throw "It appears that the nuget install hasn't worked, check output above to see whats going on"
+            Throw "It appears that the nuget install hasn't worked, check output above to see whats going on."
         }
     }
     if (Test-Path $SSDTMSbuildFolderNet46) {

--- a/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
+++ b/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
@@ -49,3 +49,4 @@ function Install-MicrosoftDataToolsMSBuild {
         return $SSDTMSbuildFolderNet40
     }
 }
+


### PR DESCRIPTION
Nuget will not work if the target path has spaces in it without double quotes.