### PR TITLE
Fixed the Install-Nuget and Install-MSDT functions

### DIFF
--- a/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
+++ b/PoshSSDTBuildDeploy/Functions/InstallMicrosoftDataToolsMsBuild.ps1
@@ -37,7 +37,6 @@ if ((Test-Path $msBuildDataTools) -eq $false) {
         [string] $DataToolsMsBuildPackageVersion,
         [string] $NuGetPath
     )
-
     Write-Verbose "Verbose Folder : $WorkingFolder" -Verbose
     Write-Verbose "DataToolsVersion : $DataToolsMsBuildPackageVersion" -Verbose 
     Write-Warning "If DataToolsVersion is blank latest will be used"
@@ -47,7 +46,7 @@ if ((Test-Path $msBuildDataTools) -eq $false) {
     else {
         Write-Verbose "Skipping Nuget download..." -Verbose
         $NuGetExe = Join-Path $NuGetPath "nuget.exe"
-        if (-not (Test-Path $NuGetExe)) {
+        if (-not (Test-Path $($NuGetExe))) {
             Throw "NuGetpath specified, but nuget exe does not exist!"
         }
     }
@@ -64,7 +63,7 @@ if ((Test-Path $msBuildDataTools) -eq $false) {
         $nugetArgs += "-version",$DataToolsMsBuildPackageVersion
     }
     Write-Host $nugetExe ($nugetArgs -join " ") -BackgroundColor White -ForegroundColor DarkGreen
-    &$nugetExe $nugetArgs  2>&1  Out-Host
+    &$nugetExe $nugetArgs  2>&1 | Out-Host
     $SSDTMSbuildFolderNet46 = "$WorkingFolder\Microsoft.Data.Tools.Msbuild\lib\net46"
     if (-not (Test-Path $SSDTMSbuildFolderNet46)) {
         $SSDTMSbuildFolderNet40 = "$WorkingFolder\Microsoft.Data.Tools.Msbuild\lib\net40"

--- a/PoshSSDTBuildDeploy/Functions/InstallNuGet.ps1
+++ b/PoshSSDTBuildDeploy/Functions/InstallNuGet.ps1
@@ -23,15 +23,15 @@ Function Install-NuGet {
         )
         $NuGetInstallUri = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
         Write-Verbose "Working Folder   : $WorkingFolder" -Verbose
-        $NugetExe = "$WorkingFolder\nuget.exe"
+        $NugetExe = $("$WorkingFolder\nuget.exe")
         if (-not (Test-Path $NugetExe)) {
             Write-Verbose "Cannot find nuget at path $WorkingFolder\nuget.exe" -Verbose
             If (($LinkStatus = Test-DownloadUri -uri $NuGetInstallUri) -ne 200) {
                 Throw "It appears that download Nuget link no longer works. "    
             }
             $sourceNugetExe = $NuGetInstallUri
-            Write-Verbose "$sourceNugetExe -OutFile $NugetExe" -Verbose
-            Invoke-WebRequest $sourceNugetExe -OutFile $NugetExe
+            Write-Verbose $sourceNugetExe -OutFile $NugetExe -Verbose
+            Invoke-WebRequest $sourceNugetExe -OutFile "$NugetExe"
             if (-not (Test-Path $NugetExe)) { 
                 Throw "It appears that the nuget download hasn't worked."
             }


### PR DESCRIPTION
Nuget installer was not checking paths with spaces properly once installed
Data Tools installer was not handling spaces in the nuget path properly when testing the path and was missing a "|" in the nuget.exe line.