### PR TITLE
Fixed bug in Install-Nuget function

### DIFF
--- a/PoshSSDTBuildDeploy/Functions/InstallNuGet.ps1
+++ b/PoshSSDTBuildDeploy/Functions/InstallNuGet.ps1
@@ -30,7 +30,7 @@ Function Install-NuGet {
                 Throw "It appears that download Nuget link no longer works. "    
             }
             $sourceNugetExe = $NuGetInstallUri
-            Write-Verbose $sourceNugetExe -OutFile $NugetExe -Verbose
+            Write-Verbose "$sourceNugetExe -OutFile $NugetExe" -Verbose
             Invoke-WebRequest $sourceNugetExe -OutFile "$NugetExe"
             if (-not (Test-Path $NugetExe)) { 
                 Throw "It appears that the nuget download hasn't worked."


### PR DESCRIPTION
Write-Verbose line right before the download/install was missing double-quotes around the text and variables.